### PR TITLE
Improve launcher with zipball downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ This project provides a minimal launcher for Minecraft written in Python. It can
 
 ## Features
 - Checks a GitHub repository for the most recent release.
-- Downloads the specified release asset when an update is found.
+- Downloads the release's `zipball_url` as a zip archive and extracts it into an `EPTA Client` folder.
 - Supports launching the game with an offline username.
 - Basic Tkinter interface to update and launch the game.
 - Lets you choose where the game files are installed.
+- Stores the username, game directory and installed version in `AppData/EPTAData` (or `~/.config/EPTAData`).
 
 ## Usage
 1. Install the dependencies:
@@ -19,8 +20,9 @@ This project provides a minimal launcher for Minecraft written in Python. It can
    ```bash
    python launcher.py
    ```
-4. Enter a username and select a game directory if the game is not installed.
-   Press **Check for Update** to download the latest release, then press **Launch**.
+4. Enter a username and select a folder where the game should be installed.
+   Press **Check for Update** to download the release via `zipball_url` and extract it.
+   Afterwards press **Launch** to start the game.
 
 ## Microsoft Login
 The launcher contains only offline launching capabilities. Implementing Microsoft (Mojang) authentication requires access to Microsoft's login services, which may not be reachable in this environment.


### PR DESCRIPTION
## Summary
- store configuration in user config folder
- extract updates into `EPTA Client`
- download releases using GitHub `zipball_url`
- keep username, game directory and installed version
- fix launching Forge jar by using `-cp` to include it on the classpath

## Testing
- `python -m py_compile launcher.py`
- `pip install -r requirements.txt`
- `python launcher.py` *(fails: no $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_68571975fc988331b7f3ae7e790d28b5