### PR TITLE
Handle long Java command via args file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This project provides a minimal launcher for Minecraft written in Python. It can
 - Stores the username, game directory and installed version in `AppData/EPTAData` (or `~/.config/EPTAData`).
 - Allows setting a custom base Java command in the config and appending extra
   launch arguments through the UI.
+- Uses a temporary argument file when launching so the Java command stays short
+  and does not hit the Windows command length limit.
 
 ## Usage
 1. Install the dependencies:
@@ -27,8 +29,10 @@ This project provides a minimal launcher for Minecraft written in Python. It can
    Afterwards press **Launch** to start the game.
    You can customise the Java command used to start the game by editing
    `config.json` inside `AppData/EPTAData` (or `~/.config/EPTAData`) and
-   changing the `base_cmd_template` value. Arguments typed in the **Additional
-   Launch Arguments** field will be appended to this command when launching.
+    changing the `base_cmd_template` value. Arguments typed in the **Additional
+    Launch Arguments** field will be appended to this command when launching.
+    The launcher writes all JVM options to a temporary `args.txt` file before
+    starting Java so the command line stays short on Windows.
 
 ## Microsoft Login
 The launcher contains only offline launching capabilities. Implementing Microsoft (Mojang) authentication requires access to Microsoft's login services, which may not be reachable in this environment.

--- a/launcher.py
+++ b/launcher.py
@@ -30,11 +30,138 @@ LAST_VERSION = None
 # Default template for launching the game. ``{jar_path}`` and ``{username}``
 # will be replaced at runtime. You can customize this template in the
 # configuration file.
-DEFAULT_CMD_TEMPLATE = (
-    r'java -Xms3031M -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:MaxGCPauseMillis=200 -XX:+AlwaysPreTouch -XX:+ParallelRefProcEnabled -XX:+UseG1GC -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M -XX:G1ReservePercent=20 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:+UseStringDeduplication -XX:MaxTenuringThreshold=1 -XX:SurvivorRatio=32 -Xmx8192M -Dfile.encoding=UTF-8 -XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump -Djava.library.path={GAME_DIR}\versions\Forge 1.20.1\natives -Djna.tmpdir={GAME_DIR}\versions\Forge 1.20.1\natives -Dorg.lwjgl.system.SharedLibraryExtractPath={GAME_DIR}\versions\Forge 1.20.1\natives -Dio.netty.native.workdir={GAME_DIR}\versions\Forge 1.20.1\natives -Dminecraft.launcher.brand=java-minecraft-launcher -Dminecraft.launcher.version=1.6.84-j -cp {GAME_DIR}\libraries\cpw\mods\securejarhandler\2.1.10\securejarhandler-2.1.10.jar;{GAME_DIR}\libraries\org\ow2\asm\asm\9.7.1\asm-9.7.1.jar;{GAME_DIR}\libraries\org\ow2\asm\asm-commons\9.7.1\asm-commons-9.7.1.jar;{GAME_DIR}\libraries\org\ow2\asm\asm-tree\9.7.1\asm-tree-9.7.1.jar;{GAME_DIR}\libraries\org\ow2\asm\asm-util\9.7.1\asm-util-9.7.1.jar;{GAME_DIR}\libraries\org\ow2\asm\asm-analysis\9.7.1\asm-analysis-9.7.1.jar;{GAME_DIR}\libraries\net\minecraftforge\accesstransformers\8.0.4\accesstransformers-8.0.4.jar;{GAME_DIR}\libraries\org\antlr\antlr4-runtime\4.9.1\antlr4-runtime-4.9.1.jar;{GAME_DIR}\libraries\net\minecraftforge\eventbus\6.0.5\eventbus-6.0.5.jar;{GAME_DIR}\libraries\net\minecraftforge\forgespi\7.0.1\forgespi-7.0.1.jar;{GAME_DIR}\libraries\net\minecraftforge\coremods\5.2.4\coremods-5.2.4.jar;{GAME_DIR}\libraries\cpw\mods\modlauncher\10.0.9\modlauncher-10.0.9.jar;{GAME_DIR}\libraries\net\minecraftforge\unsafe\0.2.0\unsafe-0.2.0.jar;{GAME_DIR}\libraries\net\minecraftforge\mergetool\1.1.5\mergetool-1.1.5-api.jar;{GAME_DIR}\libraries\com\electronwill\night-config\core\3.6.4\core-3.6.4.jar;{GAME_DIR}\libraries\com\electronwill\night-config\toml\3.6.4\toml-3.6.4.jar;{GAME_DIR}\libraries\org\apache\maven\maven-artifact\3.8.5\maven-artifact-3.8.5.jar;{GAME_DIR}\libraries\net\jodah\typetools\0.6.3\typetools-0.6.3.jar;{GAME_DIR}\libraries\net\minecrell\terminalconsoleappender\1.2.0\terminalconsoleappender-1.2.0.jar;{GAME_DIR}\libraries\org\jline\jline-reader\3.12.1\jline-reader-3.12.1.jar;{GAME_DIR}\libraries\org\jline\jline-terminal\3.12.1\jline-terminal-3.12.1.jar;{GAME_DIR}\libraries\org\spongepowered\mixin\0.8.5\mixin-0.8.5.jar;{GAME_DIR}\libraries\org\openjdk\nashorn\nashorn-core\15.4\nashorn-core-15.4.jar;{GAME_DIR}\libraries\net\minecraftforge\JarJarSelector\0.3.19\JarJarSelector-0.3.19.jar;{GAME_DIR}\libraries\net\minecraftforge\JarJarMetadata\0.3.19\JarJarMetadata-0.3.19.jar;{GAME_DIR}\libraries\cpw\mods\bootstraplauncher\1.1.2\bootstraplauncher-1.1.2.jar;{GAME_DIR}\libraries\net\minecraftforge\JarJarFileSystems\0.3.19\JarJarFileSystems-0.3.19.jar;{GAME_DIR}\libraries\net\minecraftforge\fmlloader\1.20.1-47.4.1\fmlloader-1.20.1-47.4.1.jar;{GAME_DIR}\libraries\net\minecraftforge\fmlearlydisplay\1.20.1-47.4.1\fmlearlydisplay-1.20.1-47.4.1.jar;{GAME_DIR}\libraries\com\github\oshi\oshi-core\6.2.2\oshi-core-6.2.2.jar;{GAME_DIR}\libraries\com\google\code\gson\gson\2.10\gson-2.10.jar;{GAME_DIR}\libraries\com\google\guava\failureaccess\1.0.1\failureaccess-1.0.1.jar;{GAME_DIR}\libraries\com\google\guava\guava\31.1-jre\guava-31.1-jre.jar;{GAME_DIR}\libraries\com\ibm\icu\icu4j\71.1\icu4j-71.1.jar;{GAME_DIR}\libraries\com\mojang\authlib\4.0.43\authlib-4.0.43.jar;{GAME_DIR}\libraries\com\mojang\blocklist\1.0.10\blocklist-1.0.10.jar;{GAME_DIR}\libraries\com\mojang\brigadier\1.1.8\brigadier-1.1.8.jar;{GAME_DIR}\libraries\com\mojang\datafixerupper\6.0.8\datafixerupper-6.0.8.jar;{GAME_DIR}\libraries\com\mojang\logging\1.1.1\logging-1.1.1.jar;{GAME_DIR}\libraries\ru\tln4\empty\0.1\empty-0.1.jar;{GAME_DIR}\libraries\com\mojang\text2speech\1.17.9\text2speech-1.17.9.jar;{GAME_DIR}\libraries\commons-codec\commons-codec\1.15\commons-codec-1.15.jar;{GAME_DIR}\libraries\commons-io\commons-io\2.11.0\commons-io-2.11.0.jar;{GAME_DIR}\libraries\commons-logging\commons-logging\1.2\commons-logging-1.2.jar;{GAME_DIR}\libraries\io\netty\netty-buffer\4.1.82.Final\netty-buffer-4.1.82.Final.jar;{GAME_DIR}\libraries\io\netty\netty-codec\4.1.82.Final\netty-codec-4.1.82.Final.jar;{GAME_DIR}\libraries\io\netty\netty-common\4.1.82.Final\netty-common-4.1.82.Final.jar;{GAME_DIR}\libraries\io\netty\netty-handler\4.1.82.Final\netty-handler-4.1.82.Final.jar;{GAME_DIR}\libraries\io\netty\netty-resolver\4.1.82.Final\netty-resolver-4.1.82.Final.jar;{GAME_DIR}\libraries\io\netty\netty-transport-classes-epoll\4.1.82.Final\netty-transport-classes-epoll-4.1.82.Final.jar;{GAME_DIR}\libraries\io\netty\netty-transport-native-unix-common\4.1.82.Final\netty-transport-native-unix-common-4.1.82.Final.jar;{GAME_DIR}\libraries\io\netty\netty-transport\4.1.82.Final\netty-transport-4.1.82.Final.jar;{GAME_DIR}\libraries\it\unimi\dsi\fastutil\8.5.9\fastutil-8.5.9.jar;{GAME_DIR}\libraries\net\java\dev\jna\jna-platform\5.12.1\jna-platform-5.12.1.jar;{GAME_DIR}\libraries\net\java\dev\jna\jna\5.12.1\jna-5.12.1.jar;{GAME_DIR}\libraries\net\sf\jopt-simple\jopt-simple\5.0.4\jopt-simple-5.0.4.jar;{GAME_DIR}\libraries\org\apache\commons\commons-compress\1.21\commons-compress-1.21.jar;{GAME_DIR}\libraries\org\apache\commons\commons-lang3\3.12.0\commons-lang3-3.12.0.jar;{GAME_DIR}\libraries\org\apache\httpcomponents\httpclient\4.5.13\httpclient-4.5.13.jar;{GAME_DIR}\libraries\org\apache\httpcomponents\httpcore\4.4.15\httpcore-4.4.15.jar;{GAME_DIR}\libraries\org\apache\logging\log4j\log4j-api\2.19.0\log4j-api-2.19.0.jar;{GAME_DIR}\libraries\org\apache\logging\log4j\log4j-core\2.19.0\log4j-core-2.19.0.jar;{GAME_DIR}\libraries\org\apache\logging\log4j\log4j-slf4j2-impl\2.19.0\log4j-slf4j2-impl-2.19.0.jar;{GAME_DIR}\libraries\org\joml\joml\1.10.5\joml-1.10.5.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-glfw\3.3.1\lwjgl-glfw-3.3.1.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-glfw\3.3.1\lwjgl-glfw-3.3.1-natives-windows.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-glfw\3.3.1\lwjgl-glfw-3.3.1-natives-windows-arm64.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-glfw\3.3.1\lwjgl-glfw-3.3.1-natives-windows-x86.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-jemalloc\3.3.1\lwjgl-jemalloc-3.3.1.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-jemalloc\3.3.1\lwjgl-jemalloc-3.3.1-natives-windows.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-jemalloc\3.3.1\lwjgl-jemalloc-3.3.1-natives-windows-arm64.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-jemalloc\3.3.1\lwjgl-jemalloc-3.3.1-natives-windows-x86.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-openal\3.3.1\lwjgl-openal-3.3.1.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-openal\3.3.1\lwjgl-openal-3.3.1-natives-windows.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-openal\3.3.1\lwjgl-openal-3.3.1-natives-windows-arm64.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-openal\3.3.1\lwjgl-openal-3.3.1-natives-windows-x86.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-opengl\3.3.1\lwjgl-opengl-3.3.1.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-opengl\3.3.1\lwjgl-opengl-3.3.1-natives-windows.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-opengl\3.3.1\lwjgl-opengl-3.3.1-natives-windows-arm64.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-opengl\3.3.1\lwjgl-opengl-3.3.1-natives-windows-x86.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-stb\3.3.1\lwjgl-stb-3.3.1.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-stb\3.3.1\lwjgl-stb-3.3.1-natives-windows.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-stb\3.3.1\lwjgl-stb-3.3.1-natives-windows-arm64.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-stb\3.3.1\lwjgl-stb-3.3.1-natives-windows-x86.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-tinyfd\3.3.1\lwjgl-tinyfd-3.3.1.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-tinyfd\3.3.1\lwjgl-tinyfd-3.3.1-natives-windows.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-tinyfd\3.3.1\lwjgl-tinyfd-3.3.1-natives-windows-arm64.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-tinyfd\3.3.1\lwjgl-tinyfd-3.3.1-natives-windows-x86.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl\3.3.1\lwjgl-3.3.1.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl\3.3.1\lwjgl-3.3.1-natives-windows.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl\3.3.1\lwjgl-3.3.1-natives-windows-arm64.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl\3.3.1\lwjgl-3.3.1-natives-windows-x86.jar;{GAME_DIR}\libraries\org\slf4j\slf4j-api\2.0.1\slf4j-api-2.0.1.jar;{GAME_DIR}\versions\Forge 1.20.1\Forge 1.20.1.jar -Djava.net.preferIPv6Addresses=system -DignoreList="bootstraplauncher","securejarhandler","asm-commons","asm-util","asm-analysis","asm-tree","asm","JarJarFileSystems","client-extra","fmlcore","javafmllanguage","lowcodelanguage","mclanguage","forge-","Forge 1.20.1.jar" -DmergeModules="jna-5.10.0.jar","jna-platform-5.10.0.jar" -DlibraryDirectory={GAME_DIR}\libraries -p {GAME_DIR}\libraries/cpw/mods/bootstraplauncher/1.1.2/bootstraplauncher-1.1.2.jar;{GAME_DIR}\libraries/cpw/mods/securejarhandler/2.1.10/securejarhandler-2.1.10.jar;{GAME_DIR}\libraries/org/ow2/asm/asm-commons/9.7.1/asm-commons-9.7.1.jar;{GAME_DIR}\libraries/org/ow2/asm/asm-util/9.7.1/asm-util-9.7.1.jar;{GAME_DIR}\libraries/org/ow2/asm/asm-analysis/9.7.1/asm-analysis-9.7.1.jar;{GAME_DIR}\libraries/org/ow2/asm/asm-tree/9.7.1/asm-tree-9.7.1.jar;{GAME_DIR}\libraries/org/ow2/asm/asm/9.7.1/asm-9.7.1.jar;{GAME_DIR}\libraries/net/minecraftforge/JarJarFileSystems/0.3.19/JarJarFileSystems-0.3.19.jar --add-modules ALL-MODULE-PATH --add-opens java.base/java.util.jar=cpw.mods.securejarhandler --add-opens java.base/java.lang.invoke=cpw.mods.securejarhandler --add-exports java.base/sun.security.util=cpw.mods.securejarhandler --add-exports jdk.naming.dns/com.sun.jndi.dns=java.naming -Xss2M cpw.mods.bootstraplauncher.BootstrapLauncher --version Forge 1.20.1 --gameDir {GAME_DIR} --assetsDir {GAME_DIR}\assets --assetIndex 5 --uuid c3a98f5351b53ff38de9d26d9504690c --accessToken c3a98f5351b53ff38de9d26d9504690c --clientId  --xuid  --userType legacy --versionType modified --width 925 --height 530 --launchTarget forgeclient --fml.forgeVersion 47.4.1 --fml.mcVersion 1.20.1 --fml.forgeGroup net.minecraftforge --fml.mcpVersion 20230612.114412'
-)
+# Command-line options and classpath used when launching the game.
+# {GAME_DIR} will be replaced by the selected game directory.
+JAVA_ARGS_TEMPLATE = r"""
+-Xms3031M -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:MaxGCPauseMillis=200 -XX:+AlwaysPreTouch
+-XX:+ParallelRefProcEnabled -XX:+UseG1GC -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M
+-XX:G1ReservePercent=20 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4
+-XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:+UseStringDeduplication
+-XX:MaxTenuringThreshold=1 -XX:SurvivorRatio=32 -Xmx8192M -Dfile.encoding=UTF-8
+-XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump
+-Djava.library.path={GAME_DIR}\versions\Forge 1.20.1\natives -Djna.tmpdir={GAME_DIR}\versions\Forge 1.20.1\natives
+-Dorg.lwjgl.system.SharedLibraryExtractPath={GAME_DIR}\versions\Forge 1.20.1\natives
+-Dio.netty.native.workdir={GAME_DIR}\versions\Forge 1.20.1\natives -Dminecraft.launcher.brand=java-minecraft-launcher
+-Dminecraft.launcher.version=1.6.84-j -cp {GAME_DIR}\libraries\cpw\mods\securejarhandler\2.1.10\securejarhandler-
+2.1.10.jar;{GAME_DIR}\libraries\org\ow2\asm\asm\9.7.1\asm-9.7.1.jar;{GAME_DIR}\libraries\org\ow2\asm\asm-
+commons\9.7.1\asm-commons-9.7.1.jar;{GAME_DIR}\libraries\org\ow2\asm\asm-tree\9.7.1\asm-
+tree-9.7.1.jar;{GAME_DIR}\libraries\org\ow2\asm\asm-util\9.7.1\asm-util-9.7.1.jar;{GAME_DIR}\libraries\org\ow2\asm\asm-
+analysis\9.7.1\asm-analysis-
+9.7.1.jar;{GAME_DIR}\libraries\net\minecraftforge\accesstransformers\8.0.4\accesstransformers-
+8.0.4.jar;{GAME_DIR}\libraries\org\antlr\antlr4-runtime\4.9.1\antlr4-runtime-
+4.9.1.jar;{GAME_DIR}\libraries\net\minecraftforge\eventbus\6.0.5\eventbus-
+6.0.5.jar;{GAME_DIR}\libraries\net\minecraftforge\forgespi\7.0.1\forgespi-
+7.0.1.jar;{GAME_DIR}\libraries\net\minecraftforge\coremods\5.2.4\coremods-
+5.2.4.jar;{GAME_DIR}\libraries\cpw\mods\modlauncher\10.0.9\modlauncher-
+10.0.9.jar;{GAME_DIR}\libraries\net\minecraftforge\unsafe\0.2.0\unsafe-
+0.2.0.jar;{GAME_DIR}\libraries\net\minecraftforge\mergetool\1.1.5\mergetool-1.1.5-
+api.jar;{GAME_DIR}\libraries\com\electronwill\night-
+config\core\3.6.4\core-3.6.4.jar;{GAME_DIR}\libraries\com\electronwill\night-
+config\toml\3.6.4\toml-3.6.4.jar;{GAME_DIR}\libraries\org\apache\maven\maven-artifact\3.8.5\maven-artifact-
+3.8.5.jar;{GAME_DIR}\libraries\net\jodah\typetools\0.6.3\typetools-
+0.6.3.jar;{GAME_DIR}\libraries\net\minecrell\terminalconsoleappender\1.2.0\terminalconsoleappender-
+1.2.0.jar;{GAME_DIR}\libraries\org\jline\jline-reader\3.12.1\jline-
+reader-3.12.1.jar;{GAME_DIR}\libraries\org\jline\jline-terminal\3.12.1\jline-terminal-
+3.12.1.jar;{GAME_DIR}\libraries\org\spongepowered\mixin\0.8.5\mixin-
+0.8.5.jar;{GAME_DIR}\libraries\org\openjdk\nashorn\nashorn-core\15.4\nashorn-core-
+15.4.jar;{GAME_DIR}\libraries\net\minecraftforge\JarJarSelector\0.3.19\JarJarSelector-
+0.3.19.jar;{GAME_DIR}\libraries\net\minecraftforge\JarJarMetadata\0.3.19\JarJarMetadata-
+0.3.19.jar;{GAME_DIR}\libraries\cpw\mods\bootstraplauncher\1.1.2\bootstraplauncher-
+1.1.2.jar;{GAME_DIR}\libraries\net\minecraftforge\JarJarFileSystems\0.3.19\JarJarFileSystems-
+0.3.19.jar;{GAME_DIR}\libraries\net\minecraftforge\fmlloader\1.20.1-47.4.1\fmlloader-1.20.1-
+47.4.1.jar;{GAME_DIR}\libraries\net\minecraftforge\fmlearlydisplay\1.20.1-47.4.1\fmlearlydisplay-1.20.1-
+47.4.1.jar;{GAME_DIR}\libraries\com\github\oshi\oshi-core\6.2.2\oshi-core-
+6.2.2.jar;{GAME_DIR}\libraries\com\google\code\gson\gson\2.10\gson-
+2.10.jar;{GAME_DIR}\libraries\com\google\guava\failureaccess\1.0.1\failureaccess-
+1.0.1.jar;{GAME_DIR}\libraries\com\google\guava\guava\31.1-jre\guava-31.1-
+jre.jar;{GAME_DIR}\libraries\com\ibm\icu\icu4j\71.1\icu4j-
+71.1.jar;{GAME_DIR}\libraries\com\mojang\authlib\4.0.43\authlib-
+4.0.43.jar;{GAME_DIR}\libraries\com\mojang\blocklist\1.0.10\blocklist-
+1.0.10.jar;{GAME_DIR}\libraries\com\mojang\brigadier\1.1.8\brigadier-
+1.1.8.jar;{GAME_DIR}\libraries\com\mojang\datafixerupper\6.0.8\datafixerupper-
+6.0.8.jar;{GAME_DIR}\libraries\com\mojang\logging\1.1.1\logging-1.1.1.jar;{GAME_DIR}\libraries\ru\tln4\empty\0.1\empty-
+0.1.jar;{GAME_DIR}\libraries\com\mojang\text2speech\1.17.9\text2speech-1.17.9.jar;{GAME_DIR}\libraries\commons-
+codec\commons-codec\1.15\commons-codec-1.15.jar;{GAME_DIR}\libraries\commons-io\commons-io\2.11.0\commons-
+io-2.11.0.jar;{GAME_DIR}\libraries\commons-logging\commons-logging\1.2\commons-
+logging-1.2.jar;{GAME_DIR}\libraries\io\netty\netty-buffer\4.1.82.Final\netty-
+buffer-4.1.82.Final.jar;{GAME_DIR}\libraries\io\netty\netty-codec\4.1.82.Final\netty-
+codec-4.1.82.Final.jar;{GAME_DIR}\libraries\io\netty\netty-common\4.1.82.Final\netty-
+common-4.1.82.Final.jar;{GAME_DIR}\libraries\io\netty\netty-handler\4.1.82.Final\netty-
+handler-4.1.82.Final.jar;{GAME_DIR}\libraries\io\netty\netty-resolver\4.1.82.Final\netty-
+resolver-4.1.82.Final.jar;{GAME_DIR}\libraries\io\netty\netty-transport-classes-epoll\4.1.82.Final\netty-transport-
+classes-epoll-4.1.82.Final.jar;{GAME_DIR}\libraries\io\netty\netty-transport-native-unix-common\4.1.82.Final\netty-
+transport-native-unix-common-4.1.82.Final.jar;{GAME_DIR}\libraries\io\netty\netty-transport\4.1.82.Final\netty-transport
+-4.1.82.Final.jar;{GAME_DIR}\libraries\it\unimi\dsi\fastutil\8.5.9\fastutil-
+8.5.9.jar;{GAME_DIR}\libraries\net\java\dev\jna\jna-platform\5.12.1\jna-
+platform-5.12.1.jar;{GAME_DIR}\libraries\net\java\dev\jna\jna\5.12.1\jna-5.12.1.jar;{GAME_DIR}\libraries\net\sf\jopt-
+simple\jopt-simple\5.0.4\jopt-simple-5.0.4.jar;{GAME_DIR}\libraries\org\apache\commons\commons-compress\1.21\commons-
+compress-1.21.jar;{GAME_DIR}\libraries\org\apache\commons\commons-lang3\3.12.0\commons-lang3-
+3.12.0.jar;{GAME_DIR}\libraries\org\apache\httpcomponents\httpclient\4.5.13\httpclient-
+4.5.13.jar;{GAME_DIR}\libraries\org\apache\httpcomponents\httpcore\4.4.15\httpcore-
+4.4.15.jar;{GAME_DIR}\libraries\org\apache\logging\log4j\log4j-api\2.19.0\log4j-api-
+2.19.0.jar;{GAME_DIR}\libraries\org\apache\logging\log4j\log4j-core\2.19.0\log4j-core-
+2.19.0.jar;{GAME_DIR}\libraries\org\apache\logging\log4j\log4j-slf4j2-impl\2.19.0\log4j-slf4j2-impl-
+2.19.0.jar;{GAME_DIR}\libraries\org\joml\joml\1.10.5\joml-1.10.5.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-
+glfw\3.3.1\lwjgl-glfw-3.3.1.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-glfw\3.3.1\lwjgl-glfw-3.3.1-natives-
+windows.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-glfw\3.3.1\lwjgl-glfw-3.3.1-natives-windows-
+arm64.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-glfw\3.3.1\lwjgl-glfw-3.3.1-natives-
+windows-x86.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-jemalloc\3.3.1\lwjgl-
+jemalloc-3.3.1.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-jemalloc\3.3.1\lwjgl-jemalloc-3.3.1-natives-
+windows.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-jemalloc\3.3.1\lwjgl-jemalloc-3.3.1-natives-windows-
+arm64.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-jemalloc\3.3.1\lwjgl-jemalloc-3.3.1-natives-
+windows-x86.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-openal\3.3.1\lwjgl-
+openal-3.3.1.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-openal\3.3.1\lwjgl-openal-3.3.1-natives-
+windows.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-openal\3.3.1\lwjgl-openal-3.3.1-natives-windows-
+arm64.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-openal\3.3.1\lwjgl-openal-3.3.1-natives-
+windows-x86.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-opengl\3.3.1\lwjgl-
+opengl-3.3.1.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-opengl\3.3.1\lwjgl-opengl-3.3.1-natives-
+windows.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-opengl\3.3.1\lwjgl-opengl-3.3.1-natives-windows-
+arm64.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-opengl\3.3.1\lwjgl-opengl-3.3.1-natives-
+windows-x86.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-stb\3.3.1\lwjgl-stb-3.3.1.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-
+stb\3.3.1\lwjgl-stb-3.3.1-natives-windows.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-stb\3.3.1\lwjgl-stb-3.3.1-natives-
+windows-arm64.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-stb\3.3.1\lwjgl-stb-3.3.1-natives-
+windows-x86.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-tinyfd\3.3.1\lwjgl-
+tinyfd-3.3.1.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-tinyfd\3.3.1\lwjgl-tinyfd-3.3.1-natives-
+windows.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-tinyfd\3.3.1\lwjgl-tinyfd-3.3.1-natives-windows-
+arm64.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl-tinyfd\3.3.1\lwjgl-tinyfd-3.3.1-natives-windows-
+x86.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl\3.3.1\lwjgl-3.3.1.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl\3.3.1\lwjgl-
+3.3.1-natives-windows.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl\3.3.1\lwjgl-3.3.1-natives-windows-
+arm64.jar;{GAME_DIR}\libraries\org\lwjgl\lwjgl\3.3.1\lwjgl-3.3.1-natives-
+windows-x86.jar;{GAME_DIR}\libraries\org\slf4j\slf4j-api\2.0.1\slf4j-api-2.0.1.jar;{GAME_DIR}\versions\Forge
+1.20.1\Forge 1.20.1.jar -Djava.net.preferIPv6Addresses=system -DignoreList="bootstraplauncher","securejarhandler","asm-
+commons","asm-util","asm-analysis","asm-tree","asm","JarJarFileSystems","client-
+extra","fmlcore","javafmllanguage","lowcodelanguage","mclanguage","forge-","Forge 1.20.1.jar"
+-DmergeModules="jna-5.10.0.jar","jna-platform-5.10.0.jar" -DlibraryDirectory={GAME_DIR}\libraries -p {GAME_DIR}\librarie
+s/cpw/mods/bootstraplauncher/1.1.2/bootstraplauncher-
+1.1.2.jar;{GAME_DIR}\libraries/cpw/mods/securejarhandler/2.1.10/securejarhandler-
+2.1.10.jar;{GAME_DIR}\libraries/org/ow2/asm/asm-commons/9.7.1/asm-
+commons-9.7.1.jar;{GAME_DIR}\libraries/org/ow2/asm/asm-util/9.7.1/asm-
+util-9.7.1.jar;{GAME_DIR}\libraries/org/ow2/asm/asm-analysis/9.7.1/asm-
+analysis-9.7.1.jar;{GAME_DIR}\libraries/org/ow2/asm/asm-tree/9.7.1/asm-tree-
+9.7.1.jar;{GAME_DIR}\libraries/org/ow2/asm/asm/9.7.1/asm-
+9.7.1.jar;{GAME_DIR}\libraries/net/minecraftforge/JarJarFileSystems/0.3.19/JarJarFileSystems-0.3.19.jar --add-modules
+ALL-MODULE-PATH --add-opens java.base/java.util.jar=cpw.mods.securejarhandler --add-opens
+java.base/java.lang.invoke=cpw.mods.securejarhandler --add-exports java.base/sun.security.util=cpw.mods.securejarhandler
+--add-exports jdk.naming.dns/com.sun.jndi.dns=java.naming -Xss2M cpw.mods.bootstraplauncher.BootstrapLauncher --version
+Forge 1.20.1 --gameDir {GAME_DIR} --assetsDir {GAME_DIR}\assets --assetIndex 5 --uuid c3a98f5351b53ff38de9d26d9504690c
+--accessToken c3a98f5351b53ff38de9d26d9504690c --clientId  --xuid  --userType legacy --versionType modified --width 925
+--height 530 --launchTarget forgeclient --fml.forgeVersion 47.4.1 --fml.mcVersion 1.20.1 --fml.forgeGroup
+net.minecraftforge --fml.mcpVersion 20230612.114412
+"""
+# Base command template. {ARGS_FILE} will be replaced with the path of the
+# temporary argument file created at launch time.
+DEFAULT_CMD_TEMPLATE = r"java @{ARGS_FILE}"
 BASE_CMD_TEMPLATE = DEFAULT_CMD_TEMPLATE
 EXTRA_ARGS = ""
+
+
+def write_args_file(game_dir):
+    """Write all Java arguments to a temporary file and return its path."""
+    args = JAVA_ARGS_TEMPLATE.format(GAME_DIR=game_dir)
+    tmp = tempfile.NamedTemporaryFile("w", delete=False, suffix=".txt", encoding="utf-8")
+    tmp.write(args)
+    tmp.close()
+    return tmp.name
 
 
 def load_config():
@@ -153,10 +280,11 @@ def launch_game():
     if not os.path.exists(jar_path):
         messagebox.showerror("Error", "Game not found. Update first.")
         return
-    base_cmd = DEFAULT_CMD_TEMPLATE.format(GAME_DIR=GAME_DIR, username=USERNAME)
+    args_file = write_args_file(GAME_DIR)
+    base_cmd = DEFAULT_CMD_TEMPLATE.format(ARGS_FILE=args_file)
     cmd_string = f"{base_cmd} {EXTRA_ARGS}".strip()
     logging.info(cmd_string)
-    logging.info(subprocess.Popen(cmd_string, shell=True))
+    subprocess.Popen(cmd_string, shell=True)
 
 
 class LauncherWindow(tk.Tk):


### PR DESCRIPTION
## Summary
- store the Java arguments as a multiline `JAVA_ARGS_TEMPLATE`
- add helper to write arguments to a temp file
- launch using `java @args.txt`
- document the argument file approach

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile launcher.py`

------
https://chatgpt.com/codex/tasks/task_e_6858075806bc8331a881d2c5c9ba8df0