### PR TITLE
Fix layout so controls sit at bottom

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -235,7 +235,6 @@ class LauncherWindow(QtWidgets.QWidget):
             )
 
         layout = QtWidgets.QVBoxLayout(self)
-        layout.setAlignment(QtCore.Qt.AlignTop)
 
         user_group = QtWidgets.QVBoxLayout()
         user_group.setSpacing(0)
@@ -263,6 +262,7 @@ class LauncherWindow(QtWidgets.QWidget):
         self.launch_cmd_var = QtWidgets.QLineEdit(EXTRA_ARGS)
         args_group.addWidget(self.launch_cmd_var)
         layout.addLayout(args_group)
+        layout.addStretch(1)
 
         btn_layout = QtWidgets.QHBoxLayout()
         self.update_btn = QtWidgets.QPushButton("Проверить обновления")


### PR DESCRIPTION
## Summary
- keep the main layout stretched vertically
- insert a spacer before the buttons so they stay at the bottom

## Testing
- `python -m py_compile launcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68584a59774c83318e945bf52a8557c8