### PR TITLE
Add exe build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,22 @@ This project provides a minimal launcher for Minecraft written in Python. It can
 
 ## Microsoft Login
 The launcher contains only offline launching capabilities. Implementing Microsoft (Mojang) authentication requires access to Microsoft's login services, which may not be reachable in this environment.
+
+## Building an executable
+
+To distribute the launcher as a standalone Windows application, you can build an
+`.exe` using [PyInstaller](https://pyinstaller.org/):
+
+1. Install the dependencies and PyInstaller:
+   ```bash
+   pip install -r requirements.txt
+   pip install pyinstaller
+   ```
+2. Run PyInstaller from the project directory:
+   ```bash
+   pyinstaller --onefile --add-data background.png;. launcher.py
+   ```
+   On Linux or macOS replace the semicolon (`;`) after the image name with a
+   colon (`:`).
+3. The compiled launcher will be located in the `dist` folder as
+   `launcher.exe` (or just `launcher` on non‑Windows platforms).

--- a/launcher.py
+++ b/launcher.py
@@ -5,6 +5,7 @@ import tempfile
 import shutil
 import threading
 import subprocess
+import sys
 import requests
 
 import warnings
@@ -17,6 +18,15 @@ warnings.filterwarnings(
 )
 
 from PyQt5 import QtWidgets, QtGui, QtCore
+
+
+def resource_path(relative: str) -> str:
+    """Return absolute path to resource for dev and PyInstaller."""
+    if getattr(sys, "frozen", False):
+        base_path = sys._MEIPASS  # type: ignore[attr-defined]
+    else:
+        base_path = os.path.dirname(__file__)
+    return os.path.join(base_path, relative)
 
 # Suppress deprecated SIP warnings from PyQt on Python 3.12+
 warnings.filterwarnings(
@@ -222,7 +232,7 @@ class LauncherWindow(QtWidgets.QWidget):
         self.setAttribute(QtCore.Qt.WA_StyledBackground, True)
         self.setAutoFillBackground(True)
 
-        bg_path = os.path.join(os.path.dirname(__file__), "background.png")
+        bg_path = resource_path("background.png")
         if os.path.exists(bg_path):
             # Qt stylesheets choke on backslashes; use forward slashes
             qpath = os.path.abspath(bg_path).replace("\\", "/")


### PR DESCRIPTION
## Summary
- add a `resource_path` helper so the background loads from PyInstaller bundles
- document how to build a standalone executable with PyInstaller

## Testing
- `python -m py_compile launcher.py`

------
https://chatgpt.com/codex/tasks/task_e_68584de871e483319456f4611c318990