### PR TITLE
Add desktop shortcut button

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project provides a minimal launcher for Minecraft written in Python. It can
   launch arguments through the UI.
 - Uses a temporary argument file when launching so the Java command stays short
   and does not hit the Windows command length limit.
+- Provides a button to add a desktop shortcut for quickly launching the game.
 
 ## Usage
 1. Install the dependencies:

--- a/launcher_v2.py
+++ b/launcher_v2.py
@@ -246,6 +246,45 @@ def start_game(show_console: bool):
     QtCore.QTimer.singleShot(300, lambda: Backend.instance.progressChanged.emit("", 0))
 
 
+def get_desktop_dir() -> str:
+    """Return path to the user's desktop directory."""
+    if os.name == "nt":
+        return os.path.join(os.environ.get("USERPROFILE", os.path.expanduser("~")), "Desktop")
+    return os.path.join(os.path.expanduser("~"), "Desktop")
+
+
+def create_desktop_shortcut() -> str:
+    """Create a launcher shortcut on the desktop and return the path."""
+    desktop = get_desktop_dir()
+    os.makedirs(desktop, exist_ok=True)
+
+    if getattr(sys, "frozen", False):
+        target_cmd = f'"{sys.executable}"'
+    else:
+        script = os.path.abspath(__file__)
+        target_cmd = f'"{sys.executable}" "{script}"'
+
+    if os.name == "nt":
+        shortcut_path = os.path.join(desktop, "EPTA Launcher.bat")
+        with open(shortcut_path, "w", encoding="utf-8") as f:
+            f.write(f"@echo off\n{target_cmd}\n")
+    else:
+        shortcut_path = os.path.join(desktop, "EPTA Launcher.desktop")
+        icon_path = resource_path("static/img/epta_icon_64x64.ico")
+        with open(shortcut_path, "w", encoding="utf-8") as f:
+            f.write("[Desktop Entry]\n")
+            f.write("Type=Application\n")
+            f.write("Name=EPTA Launcher\n")
+            f.write(f"Exec={target_cmd}\n")
+            f.write(f"Path={os.path.dirname(sys.executable)}\n")
+            if os.path.exists(icon_path):
+                f.write(f"Icon={icon_path}\n")
+            f.write("Terminal=false\n")
+        os.chmod(shortcut_path, 0o755)
+
+    return shortcut_path
+
+
 class Backend(QtCore.QObject):
     instance = None
     progressChanged = QtCore.pyqtSignal(str, float)
@@ -298,6 +337,14 @@ class Backend(QtCore.QObject):
     def browse_dir(self):
         path = QtWidgets.QFileDialog.getExistingDirectory(None, "Выберите директорию для игры", GAME_DIR)
         return path or ""
+
+    @QtCore.pyqtSlot(result=str)
+    def create_shortcut(self):
+        try:
+            path = create_desktop_shortcut()
+            return f"Ярлык создан: {path}"
+        except Exception as e:
+            return f"Ошибка создания ярлыка: {e}"
 
     @QtCore.pyqtSlot()
     def close_game(self):

--- a/static/html/main_launcher.html
+++ b/static/html/main_launcher.html
@@ -55,6 +55,9 @@
         <div class="text-center mt-2">
           <button type="button" onclick="updateGame()" class="btn btn-outline-light">Проверить обновления</button>
         </div>
+        <div class="text-center mt-2">
+          <button type="button" onclick="createShortcut()" class="btn btn-outline-light">Добавить ярлык</button>
+        </div>
       </form>
     </div>
     <div class="col-8">
@@ -155,14 +158,20 @@
       }
     }
 
-    function updateGame(quiet=false) {
+  function updateGame(quiet=false) {
       const username = document.getElementById('username').value;
       const gameDir = document.getElementById('game_dir').value;
       const extra = document.getElementById('extra_args').value;
       const ram = parseInt(document.getElementById('ram').value || 0);
       const autoUpdate = document.getElementById('auto_update').checked;
       backend.update_game(gameDir, username, extra, ram, autoUpdate, quiet);
+  }
+
+  function createShortcut() {
+    if (backend.create_shortcut) {
+      backend.create_shortcut(function(msg) { alert(msg); });
     }
+  }
 
     function launchGame() {
       if (gameRunning) {


### PR DESCRIPTION
## Summary
- add ability to create a desktop shortcut in `launcher_v2.py`
- expose shortcut creation via Backend API
- add button and JS hook in HTML UI
- document the new feature in README

## Testing
- `python -m py_compile launcher_v2.py`


------
https://chatgpt.com/codex/tasks/task_e_685e9e897fc4833193baf64a7093b53d